### PR TITLE
Avoid double site URL concatenation

### DIFF
--- a/onelogin-saml-sso/php/settings.php
+++ b/onelogin-saml-sso/php/settings.php
@@ -57,7 +57,7 @@ if (empty($requested_authncontext_values)) {
     }
 }
 
-$acs_endpoint = get_site_url() . (get_option('onelogin_saml_alternative_acs', false) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : '/wp-login.php?saml_acs');
+$acs_endpoint = get_option('onelogin_saml_alternative_acs', false) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : wp_login_url() . '?saml_acs';
 
 $settings = array (
 


### PR DESCRIPTION
With #29, the URL was updated to use `plugins_url()` for alternative acs, but is still accidentally concatenated with `site_url()`, giving an invalid URL like `http://example.comhttp://example.com/wp-content/...`

While I was here, I also changed the site URL call to just use `wp_login_url()`