### PR TITLE
Add check for SAMLResponse param to work around keycloak redirect

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -17,7 +17,7 @@ function saml_checker() {
 		}
 		saml_acs();
 	}
-	else if (isset($_GET['saml_sls'])) {
+	else if (isset($_GET['saml_sls']) || isset($_GET['SAMLResponse'])) {
 		saml_sls();
 	} else if (isset($_GET['saml_metadata'])) {
 		saml_metadata();


### PR DESCRIPTION
I'm working with Keycloak as an IdP and was testing an integration with Wordpress. 

The problem I ran into was during the logout flow. 

Wordpress redirects to Keycloak to request a logout and on the redirect back to Wordpress Keycloak will neglect to include the `?saml_sls` get parameter that triggers the plugin. (based on my rudimentary understanding after two days of looking at the plugin code)

I added this additional check for a `SAMLResponse` parameter as well. Now, the plugin correctly logs the user out of Wordpress when it receives the saml response from keycloak with `SAMLResponse` as the only get parameter. With the configuration I used, the plugin now correctly redirects the user back to keycloak to authenticate/login.

I understand this might not be desirable but I'm submitting the PR to gather additional comments and feedback.