### PR TITLE
Allow WP-CLI to work

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -60,6 +60,10 @@ function saml_user_register() {
 }
 
 function saml_sso() {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+	
 	if (is_user_logged_in()) {
 		return true;
 	}


### PR DESCRIPTION
When `onelogin_saml_forcelogin` is enabled, [WP-CLI](http://wp-cli.org/) will silently exit.