### PR TITLE
Fix wrong and missing late escaping.

### DIFF
--- a/onelogin-saml-sso/php/compatibility.php
+++ b/onelogin-saml-sso/php/compatibility.php
@@ -6,7 +6,7 @@ if (!function_exists('wp_roles'))
         global $wp_roles;
      
         if ( ! isset( $wp_roles ) ) {
-            $wp_roles = new WP_Roles();
+            $wp_roles = new WP_Roles(); // Override ok.
         }
         return $wp_roles;
     }

--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -17,11 +17,11 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 			<div class="wrap">
 				<?php screen_icon(); ?>
 				<div class="alignleft">
-					<a href="http://www.onelogin.com"><img src="<?php echo plugins_url('onelogin.png', dirname(__FILE__));?>"></a>
+					<a href="http://www.onelogin.com"><img src="<?php echo esc_url( plugins_url('onelogin.png', dirname(__FILE__)) );?>"></a>
 				</div>
 				<div class="alignright">
-					<a href="<?php echo get_site_url().'/wp-login.php?saml_metadata'; ?>" target="blank"><?php echo __("Go to the metadata of this SP", 'onelogin-saml-sso');?></a><br>
-					<a href="<?php echo get_site_url().'/wp-login.php?saml_validate_config'; ?>" target="blank"><?php echo __("Once configured, validate here your OneLogin SSO/SAML Settings", 'onelogin-saml-sso');?></a>
+					<a href="<?php echo esc_url( get_site_url().'/wp-login.php?saml_metadata' ); ?>" target="blank"><?php echo __("Go to the metadata of this SP", 'onelogin-saml-sso');?></a><br>
+					<a href="<?php echo esc_url( get_site_url().'/wp-login.php?saml_validate_config' ); ?>" target="blank"><?php echo __("Once configured, validate here your OneLogin SSO/SAML Settings", 'onelogin-saml-sso');?></a>
 				</div>
 				<div style="clear:both"></div>
 				<h2><?php echo esc_html( $title ); ?></h2>
@@ -184,7 +184,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 
 	function plugin_setting_string_onelogin_saml_idp_entityid() {
 		echo '<input type="text" name="onelogin_saml_idp_entityid" id="onelogin_saml_idp_entityid"
-			  value= "'.esc_html(get_option('onelogin_saml_idp_entityid')).'" size="80">'.
+			  value= "'.esc_attr(get_option('onelogin_saml_idp_entityid')).'" size="80">'.
 			  '<p class="description">'.__('Identifier of the IdP entity. ("Issuer URL")', 'onelogin-saml-sso').'</p>';
 	}
 
@@ -273,37 +273,37 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 
 	function plugin_setting_string_onelogin_saml_attr_mapping_mail() {
 		echo '<input type="text" name="onelogin_saml_attr_mapping_mail" id="onelogin_saml_attr_mapping_mail"
-			  value= "'.esc_html(get_option('onelogin_saml_attr_mapping_mail')).'" size="30">';
+			  value= "'.esc_attr(get_option('onelogin_saml_attr_mapping_mail')).'" size="30">';
 	}
 
 	function plugin_setting_string_onelogin_saml_attr_mapping_firstname() {
 		echo '<input type="text" name="onelogin_saml_attr_mapping_firstname" id="onelogin_saml_attr_mapping_firstname"
-			  value= "'.esc_html(get_option('onelogin_saml_attr_mapping_firstname')).'" size="30">';
+			  value= "'.esc_attr(get_option('onelogin_saml_attr_mapping_firstname')).'" size="30">';
 	}
 
 	function plugin_setting_string_onelogin_saml_attr_mapping_lastname() {
 		echo '<input type="text" name="onelogin_saml_attr_mapping_lastname" id="onelogin_saml_attr_mapping_lastname"
-			  value= "'.esc_html(get_option('onelogin_saml_attr_mapping_lastname')).'" size="30">';
+			  value= "'.esc_attr(get_option('onelogin_saml_attr_mapping_lastname')).'" size="30">';
 	}
 
 	function plugin_setting_string_onelogin_saml_attr_mapping_role() {
 		echo '<input type="text" name="onelogin_saml_attr_mapping_role" id="onelogin_saml_attr_mapping_role"
-			  value= "'.esc_html(get_option('onelogin_saml_attr_mapping_role')).'" size="30">'.
+			  value= "'.esc_attr(get_option('onelogin_saml_attr_mapping_role')).'" size="30">'.
 			  '<p class="description">'.__("The attribute that contains the role of the user, For example 'memberOf'. If WordPress can't figure what role assign to the user, it will assign the default role defined at the general settings.", 'onelogin-saml-sso').'</p>';
 	}
 
 	function plugin_setting_string_onelogin_saml_role_mapping($role_value) {
-		echo '<input type="text" name="onelogin_saml_role_mapping_'.$role_value.'" id="onelogin_saml_role_mapping_'.$role_value.'"
-			  value= "'.esc_html(get_option('onelogin_saml_role_mapping_'.$role_value)).'" size="30">';
+		echo '<input type="text" name="onelogin_saml_role_mapping_'.esc_attr($role_value).'" id="onelogin_saml_role_mapping_'.esc_attr($role_value).'"
+			  value= "'.esc_attr(get_option('onelogin_saml_role_mapping_'.$role_value)).'" size="30">';
 	}
 
 	function plugin_setting_string_onelogin_saml_role_order($role_value) {
-		echo '<input type="text" name="onelogin_saml_role_order_'.$role_value.'" id="onelogin_saml_role_order_'.$role_value.'"
-			  value= "'.esc_html(get_option('onelogin_saml_role_order_'.$role_value)).'" size="3">';
+		echo '<input type="text" name="onelogin_saml_role_order_'.esc_attr($role_value).'" id="onelogin_saml_role_order_'.esc_attr($role_value).'"
+			  value= "'.esc_attr(get_option('onelogin_saml_role_order_'.$role_value)).'" size="3">';
 	}
 
 	function plugin_setting_boolean_onelogin_saml_role_mapping_multivalued_in_one_attribute_value() {
-		$value = esc_html(get_option('onelogin_saml_role_mapping_multivalued_in_one_attribute_value'));
+		$value = get_option('onelogin_saml_role_mapping_multivalued_in_one_attribute_value');
 		echo '<input type="checkbox" name="onelogin_saml_role_mapping_multivalued_in_one_attribute_value" id="onelogin_saml_role_mapping_multivalued_in_one_attribute_value"
 			  '.($value ? 'checked="checked"': '').'>
 			  <p class="description">'.__("Sometimes role values are provided in an unique attribute statement (instead multiple attribute statements). If that is the case, activate this and the plugin will try to split those values by ;<br>Use a regular expression pattern in order to extract complex data.", 'onelogin-saml-sso').'</p>';
@@ -311,7 +311,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 
 	function plugin_setting_string_onelogin_saml_role_mapping_multivalued_pattern() {
 		echo '<input type="text" name="onelogin_saml_role_mapping_multivalued_pattern" id="onelogin_saml_role_mapping_multivalued_pattern"
-			  value= "'.esc_html(get_option('onelogin_saml_role_mapping_multivalued_pattern')).'" size="70">
+			  value= "'.esc_attr(get_option('onelogin_saml_role_mapping_multivalued_pattern')).'" size="70">
 			  <p class="description">'.__("Regular expression that extract roles from complex multivalued data (required to active the previous option).<br> E.g. If the SAMLResponse has a role attribute like: CN=admin;CN=superuser;CN=europe-admin; , use the regular expression <code>/CN=([A-Z0-9\s _-]*);/i</code> to retrieve the values. Or use <code>/CN=([^,;]*)/</code>", 'onelogin-saml-sso').'</p>';
 	}
 
@@ -477,7 +477,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 		echo '<select name="onelogin_saml_advanced_nameidformat" id="onelogin_saml_advanced_nameidformat">';
 
 		foreach ($posible_nameidformat_values as $key => $value) {
-			echo '<option value='.$key.' '.($key == $nameidformat_value ? 'selected="selected"': '').' >'.$value.'</option>';
+			echo '<option value='.esc_attr($key).' '.($key == $nameidformat_value ? 'selected="selected"': '').' >'.esc_html($value).'</option>';
 		}
 
 		echo '</select>'.
@@ -503,7 +503,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 		echo '<select multiple="multiple" name="onelogin_saml_advanced_requestedauthncontext[]" id="onelogin_saml_advanced_requestedauthncontext">';
 		echo '<option value=""></option>';
 		foreach ($posible_requestedauthncontext_values as $key => $value) {
-			echo '<option value='.$key.' '.(in_array($key, $requestedauthncontext_values) ? 'selected="selected"': '').' >'.$value.'</option>';
+			echo '<option value='.esc_attr($key).' '.(in_array($key, $requestedauthncontext_values) ? 'selected="selected"': '').' >'.esc_html($value).'</option>';
 		}
 
 		echo '</select>'.
@@ -524,7 +524,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 		echo '<select name="onelogin_saml_advanced_signaturealgorithm" id="onelogin_saml_advanced_signaturealgorithm">';
 
 		foreach ($posible_signaturealgorithm_values as $key => $value) {
-			echo '<option value='.$key.' '.($key == $signaturealgorithm_value ? 'selected="selected"': '').' >'.$value.'</option>';
+			echo '<option value='.esc_attr($key).' '.($key == $signaturealgorithm_value ? 'selected="selected"': '').' >'.esc_html($value).'</option>';
 		}
 
 		echo '</select>'.
@@ -543,7 +543,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 		echo '<select name="onelogin_saml_advanced_digestalgorithm" id="onelogin_saml_advanced_digestalgorithm">';
 
 		foreach ($posible_digestalgorithm_values as $key => $value) {
-			echo '<option value='.$key.' '.($key == $digestalgorithm_value ? 'selected="selected"': '').' >'.$value.'</option>';
+			echo '<option value='.esc_attr($key).' '.($key == $digestalgorithm_value ? 'selected="selected"': '').' >'.esc_html($value).'</option>';
 		}
 
 		echo '</select>'.

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -32,7 +32,7 @@ function saml_custom_login_footer() {
 		$saml_login_message = "SAML Login";
 	}
 
-    echo '<div style="font-size: 110%;padding:8px;background: #fff;text-align: center;"><a href="'.get_site_url().'/wp-login.php?saml_sso">'.esc_html($saml_login_message).'</a></div>';
+    echo '<div style="font-size: 110%;padding:8px;background: #fff;text-align: center;"><a href="'.esc_url( get_site_url().'/wp-login.php?saml_sso') .'">'.esc_html($saml_login_message).'</a></div>';
 }
 
 function saml_load_translations() {
@@ -372,7 +372,7 @@ function initialize_saml() {
 	} catch (Exception $e) {
 		echo '<br>'.__("The Onelogin SSO/SAML plugin is not correctly configured.", 'onelogin-saml-sso').'<br>';
 		echo esc_html($e->getMessage());
-		echo '<br>'.__("If you are the administrator", 'onelogin-saml-sso').', <a href="'.get_site_url().'/wp-login.php?normal">'.__("access using your wordpress credentials", 'onelogin-saml-sso').'</a> '.__("and fix the problem", 'onelogin-saml-sso');
+		echo '<br>'.__("If you are the administrator", 'onelogin-saml-sso').', <a href="'.esc_url( get_site_url().'/wp-login.php?normal').'">'.__("access using your wordpress credentials", 'onelogin-saml-sso').'</a> '.__("and fix the problem", 'onelogin-saml-sso');
 		exit();
 	}
 

--- a/onelogin-saml-sso/php/validate.php
+++ b/onelogin-saml-sso/php/validate.php
@@ -55,7 +55,7 @@ $fileSystemKeyExists = file_exists(plugin_dir_path(__FILE__).'certs/sp.key');
 $fileSystemCertExists = file_exists(plugin_dir_path(__FILE__).'certs/sp.crt');
 if ($fileSystemKeyExists) {
 	$privatekey_url = plugins_url('php/certs/sp.key', __DIR__);
-	echo '<br>'.__("There is a private key stored at the filesystem. Protect the 'certs' path. Nobody should be allowed to access:", 'onelogin-saml-sso').'<br>'.$privatekey_url.'<br>';
+	echo '<br>'.__("There is a private key stored at the filesystem. Protect the 'certs' path. Nobody should be allowed to access:", 'onelogin-saml-sso').'<br>'.esc_html( $privatekey_url ).'<br>';
 }
 
 if ($spPrivatekey && !empty($spPrivatekey)) {
@@ -110,7 +110,7 @@ foreach ($attr_mappings as $field => $name) {
 
 if (!empty($lacked_attr_mappings)) {
 	echo '<br>'.__("Notice that there are attributes without mapping:", 'onelogin-saml-sso').'<br>';
-	echo implode('<br>', $lacked_attr_mappings).'</br>';
+	echo wp_kses( implode('<br>',$lacked_attr_mappings), array( 'br' => array() ) ).'</br>';
 }
 
 $lacked_role_mappings = array();
@@ -128,12 +128,12 @@ foreach (wp_roles()->get_names() as $roleid => $name) {
 
 if (!empty($lacked_role_mappings)) {
 	echo '<br>'.__("Notice that there are roles without mapping:", 'onelogin-saml-sso').'<br>';
-	echo implode('<br>', $lacked_role_mappings).'</br>';
+	echo wp_kses( implode('<br>', $lacked_role_mappings ), array( 'br' => array() ) ).'</br>';
 }
 
 if (!empty($lacked_role_orders)) {
 	echo '<br>'.__("Notice that there are roles without ordering:", 'onelogin-saml-sso').'<br>';
-	echo implode('<br>', $lacked_role_orders).'</br>';
+	echo wp_kses( implode('<br>', $lacked_role_orders), array( 'br' => array() ) ).'</br>';
 }
 ?>
 


### PR DESCRIPTION
As the plugin is being used on the WordPress.com VIP platform, we have noticed some minor escaping issues while doing code review of the plugin. This commit is fixing the escaping related issues in order to make sure we don't have to patch the plugin for our clients on the platform.

*In some cases, there is `esc_html` used for escaping HTML attribute (`esc_attr` should be used instead).
*In other cases, an escaping function is missing altogether.
*Not all URLs are being properly escaped. This commit is adding `esc_url` everywhere, where valid URL is expected.

This PR also contains one PHPCS related comment - `// Override ok.` which assures PHPCS that the override of a global variable is okay.