### PR TITLE
Refactor query string parsing for RelayState redirect

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -291,10 +291,8 @@ function saml_acs() {
 			wp_redirect(home_url());
 		} else {
 			if (strpos($_REQUEST['RelayState'], 'redirect_to') !== false) {
-				$urlinfo = parse_url($_REQUEST['RelayState']);
-				$parameters = array();
-				parse_str($urlinfo['query'], $parameters);
-				$target = urldecode($parameters['redirect_to']);
+				$query = wp_parse_url($_REQUEST['RelayState'], PHP_URL_QUERY);
+				parse_str( $query, $parameters );
 				wp_redirect(urldecode($parameters['redirect_to']));
 			}  else {
 				wp_redirect($_REQUEST['RelayState']);


### PR DESCRIPTION
This commit is replacing `parse_url` by `wp_parse_url` function, which is a WordPress wrapper for PHP inconsistencies. While working on related code, this PR is cleaning up the code.

* There is no need to parse and obtain whole url. Passing PHP_URL_QUERY to `wp_parse_url` function gets us just the bit we need.
* There is no need to define the `$result` param prior calling `parse_str` function.
* variable `$target` is not being used. Thus has been removed.