### PR TITLE
Always exit after wp_redirect

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -47,7 +47,7 @@ function saml_lostpassword() {
 	$target = get_option('onelogin_saml_customize_links_lost_password');
 	if (!empty($target)) {
 		wp_redirect($target);
-		return false;
+		exit;
 	}
 }
 
@@ -55,7 +55,7 @@ function saml_user_register() {
 	$target = get_option('onelogin_saml_customize_links_user_registration');
 	if (!empty($target)) {
 		wp_redirect($target);
-		return false;
+		exit;
 	}
 }
 


### PR DESCRIPTION
As the SSO plugin should be the autoritative login solution running on a site, it should enforce redirection in case it's needed.

This commit replaced `return false;` with `exit;` in `saml_lostpassword` and `saml_user_register` functions. That way, we make sure the redirection happens early and would be the very last action of the HTTP request in WordPress.

See https://developer.wordpress.org/reference/functions/wp_redirect/