### PR TITLE
Use constants for storing cookie names

### DIFF
--- a/onelogin-saml-sso/onelogin_saml.php
+++ b/onelogin-saml-sso/onelogin_saml.php
@@ -14,6 +14,20 @@ if ( !function_exists( 'add_action' ) ) {
 	exit;
 }
 
+// Allow cookie name overriding by defining following constants prior this point. Eg.: in wp-config.php.
+if ( false === defined( 'SAML_LOGIN_COOKIE' ) ) {
+	define( 'SAML_LOGIN_COOKIE', 'saml_login' );
+}
+if ( false === defined( 'SAML_NAMEID_COOKIE' ) ) {
+	define( 'SAML_NAMEID_COOKIE', 'saml_nameid' );
+}
+if ( false === defined( 'SAML_SESSIONINDEX_COOKIE' ) ) {
+	define( 'SAML_SESSIONINDEX_COOKIE', 'saml_sessionindex' );
+}
+if ( false === defined( 'SAML_NAMEID_FORMAT_COOKIE' ) ) {
+	define( 'SAML_NAMEID_FORMAT_COOKIE', 'saml_nameid_format' );
+}
+
 require_once plugin_dir_path(__FILE__)."php/functions.php";
 require_once plugin_dir_path(__FILE__)."php/configuration.php";
 
@@ -39,7 +53,7 @@ if ($prevent_reset_password) {
 $action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'login';
 
 // Handle SLO
-if (isset($_COOKIE['saml_login']) && get_option('onelogin_saml_slo')) { 
+if (isset($_COOKIE[SAML_LOGIN_COOKIE]) && get_option('onelogin_saml_slo')) {
 	add_action('init', 'saml_slo', 1);
 }
 

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -88,14 +88,14 @@ function saml_slo() {
 			$sessionIndex = null;
 			$nameIdFormat = null;
 
-			if (isset($_COOKIE['saml_nameid'])) {
-				$nameId = $_COOKIE['saml_nameid']; 
+			if (isset($_COOKIE[SAML_NAMEID_COOKIE])) {
+				$nameId = $_COOKIE[SAML_NAMEID_COOKIE];
 			}
-			if (isset($_COOKIE['saml_sessionindex'])) {
-				$sessionIndex = $_COOKIE['saml_sessionindex'];
+			if (isset($_COOKIE[SAML_SESSIONINDEX_COOKIE])) {
+				$sessionIndex = $_COOKIE[SAML_SESSIONINDEX_COOKIE];
 			}
-			if (isset($_COOKIE['saml_nameid_format'])) {
-				$nameIdFormat = $_COOKIE['saml_nameid_format'];
+			if (isset($_COOKIE[SAML_NAMEID_FORMAT_COOKIE])) {
+				$nameIdFormat = $_COOKIE[SAML_NAMEID_FORMAT_COOKIE];
 			}
 
 			$auth = initialize_saml();
@@ -149,9 +149,9 @@ function saml_acs() {
 		exit();
 	}
 
-	setcookie('saml_nameid', $auth->getNameId(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
-	setcookie('saml_sessionindex', $auth->getSessionIndex(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
-	setcookie('saml_nameid_format', $auth->getNameIdFormat(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
+	setcookie(SAML_NAMEID_COOKIE, $auth->getNameId(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
+	setcookie(SAML_SESSIONINDEX_COOKIE, $auth->getSessionIndex(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
+	setcookie(SAML_NAMEID_FORMAT_COOKIE, $auth->getNameIdFormat(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
 
 	$attrs = $auth->getAttributes();
 
@@ -281,7 +281,7 @@ function saml_acs() {
 	} else if ($user_id) {
 		wp_set_current_user($user_id);
 		wp_set_auth_cookie($user_id);
-		setcookie('saml_login', 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
+		setcookie(SAML_LOGIN_COOKIE, 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
 		#do_action('wp_login', $user_id);
 		#wp_signon($user_id);
 	}
@@ -318,10 +318,10 @@ function saml_sls() {
 	$errors = $auth->getErrors();
 	if (empty($errors)) {
 		wp_logout();
-		setcookie('saml_login', 0, time() - 3600, SITECOOKIEPATH );
-		setcookie('saml_nameid', null, time() - 3600, SITECOOKIEPATH );
-		setcookie('saml_sessionindex', null, time() - 3600, SITECOOKIEPATH );
-		setcookie('saml_nameid_format', null, time() - 3600, SITECOOKIEPATH );
+		setcookie(SAML_LOGIN_COOKIE, 0, time() - 3600, SITECOOKIEPATH );
+		setcookie(SAML_NAMEID_COOKIE, null, time() - 3600, SITECOOKIEPATH );
+		setcookie(SAML_SESSIONINDEX_COOKIE, null, time() - 3600, SITECOOKIEPATH );
+		setcookie(SAML_NAMEID_FORMAT_COOKIE, null, time() - 3600, SITECOOKIEPATH );
 
 		if (get_option('onelogin_saml_forcelogin') && get_option('onelogin_saml_customize_stay_in_wordpress_after_slo')) {
 			wp_redirect(home_url().'/wp-login.php?loggedout=true');


### PR DESCRIPTION
Storing cookie names in constants allows overriding the cookie names.

Eg.: on the VIP Go platform (part of the WordPress.com VIP offering), we do automatically whitelist cookies prefixed with `wordpress_` in our Varnish configuration. Being able to change cookie names allows us to not introduce new Varnish and Nginx rules for this plugin specifically.

Also, actually, for clients using the plugin on our platform, we had to modify the names which makes it's updates more involved.