### PR TITLE
Add Remember Me option

### DIFF
--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -1,15 +1,4 @@
 <?php
-
-/* 
- * includes capabilities for a "remember me" login flag passed as a SAML Attribute.
- * To use, pass a value of 'yes' in a SAML Attribute (for example, coming from a 'remember me'
- * checkbox on a custom login), then map that attribute
- * name to the WordPress Dashboard SSO Settings here:
- * Wordpress Settings => SSO/SAML Settings => Attribute Mapping => Remember Me
- 
- * Other affected files: /php/functions.php
-*/
-
 // Make sure we don't expose any info if called directly
 if ( !function_exists( 'add_action' ) ) {
 	echo 'Hi there!  I\'m just a plugin, not much I can do when called directly.';

--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -1,5 +1,15 @@
 <?php
 
+/* 
+ * includes capabilities for a "remember me" login flag passed as a SAML Attribute.
+ * To use, pass a value of 'yes' in a SAML Attribute (for example, coming from a 'remember me'
+ * checkbox on a custom login), then map that attribute
+ * name to the WordPress Dashboard SSO Settings here:
+ * Wordpress Settings => SSO/SAML Settings => Attribute Mapping => Remember Me
+ 
+ * Other affected files: /php/functions.php
+*/
+
 // Make sure we don't expose any info if called directly
 if ( !function_exists( 'add_action' ) ) {
 	echo 'Hi there!  I\'m just a plugin, not much I can do when called directly.';
@@ -86,7 +96,8 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 			'onelogin_saml_attr_mapping_mail' => __('E-mail', 'onelogin-saml-sso') . ' *',
 			'onelogin_saml_attr_mapping_firstname' => __('First Name', 'onelogin-saml-sso'),
 			'onelogin_saml_attr_mapping_lastname' => __('Last Name', 'onelogin-saml-sso'),
-			'onelogin_saml_attr_mapping_role' => __('Role', 'onelogin-saml-sso')
+			'onelogin_saml_attr_mapping_role' => __('Role', 'onelogin-saml-sso'),
+			'onelogin_saml_attr_mapping_rememberme' => __('Remember Me', 'onelogin-saml-sso')
 		);
 		foreach ($mapping_fields as $name => $description) {
 			register_setting($option_group, $name);
@@ -284,6 +295,11 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 	function plugin_setting_string_onelogin_saml_attr_mapping_lastname() {
 		echo '<input type="text" name="onelogin_saml_attr_mapping_lastname" id="onelogin_saml_attr_mapping_lastname"
 			  value= "'.esc_attr(get_option('onelogin_saml_attr_mapping_lastname')).'" size="30">';
+	}
+
+	function plugin_setting_string_onelogin_saml_attr_mapping_rememberme() {
+		echo '<input type="text" name="onelogin_saml_attr_mapping_rememberme" id="onelogin_saml_attr_mapping_rememberme"
+			  value= "'.esc_html(get_option('onelogin_saml_attr_mapping_rememberme')).'" size="30">';
 	}
 
 	function plugin_setting_string_onelogin_saml_attr_mapping_role() {

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -305,7 +305,7 @@ function saml_acs() {
 			wp_set_auth_cookie($user_id);
 		}
 
-		setcookie('saml_login', 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
+		setcookie(SAML_LOGIN_COOKIE, 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
 	}
 
 	if (isset($_REQUEST['RelayState'])) {

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -1,12 +1,4 @@
 <?php
-/* 
- * includes capabilities for a "remember me" login flag passed as a SAML Attribute.
- * To use, pass a value of 'yes' in a SAML Attribute, then map that attribute
- * name in the WordPress Dashboard SSO Settings here:
- * Wordpress Settings => SSO/SAML Settings => Attribute Mapping => Remember Me
- 
- * Other affected files: /php/configuration.php
-*/
 
 // Make sure we don't expose any info if called directly
 if ( !function_exists( 'add_action' ) ) {
@@ -289,21 +281,12 @@ function saml_acs() {
 	} else if ($user_id) {
 		wp_set_current_user($user_id);
 		
+		$rememberme = false;
 		$remembermeMapping = get_option('onelogin_saml_attr_mapping_rememberme');
-		if ( !empty($remembermeMapping) && isset($attrs[$remembermeMapping]) && !empty($attrs[$remembermeMapping][0])) {
-			$rememberme = $attrs[$remembermeMapping][0];
+		if (!empty($remembermeMapping) && isset($attrs[$remembermeMapping]) && !empty($attrs[$remembermeMapping][0])) {
+    			$rememberme = in_array($attrs[$remembermeMapping][0], array(1, true, '1', 'yes', 'on')) ? true : false;
 		}
-		   
-		if ( isset($rememberme) ) {
-			// ** Value of 'yes' is assumed to be passed here, if other, need to edit this. 
-			if ( $rememberme == 'yes' ) {
-				wp_set_auth_cookie($user_id, true);
-			} else {
-				wp_set_auth_cookie($user_id);
-			}
-		} else {
-			wp_set_auth_cookie($user_id);
-		}
+		wp_set_auth_cookie($user_id, $rememberme);
 
 		setcookie(SAML_LOGIN_COOKIE, 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
 	}


### PR DESCRIPTION
If an IDP login / Authentication has a Remember Me option (such as a checkbox), that value can be set as a SAML Attribute and mapped in WordPress, to utilize WordPress's default 'Remember Me' function.

This effectively logs a person into WordPress for 14 days compared to the session cookie of 24 hours or browser close. 