### PR TITLE
add back code that was accidentally removed?

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -319,6 +319,8 @@ function saml_acs() {
 		setcookie(SAML_LOGIN_COOKIE, 1, time() + YEAR_IN_SECONDS, SITECOOKIEPATH );
 	}
 
+	do_action( 'onelogin_saml_attrs', $attrs, wp_get_current_user(), get_current_user_id() );
+	
 	if (isset($_REQUEST['RelayState'])) {
 		if (!empty($_REQUEST['RelayState']) && ((substr($_REQUEST['RelayState'], -strlen('/wp-login.php')) === '/wp-login.php') || (substr($_REQUEST['RelayState'], -strlen('/alternative_acs.php')) === '/alternative_acs.php'))) {
 			wp_redirect(home_url());


### PR DESCRIPTION
…ordPress action

This was merged in previously but someone removed it (see https://github.com/onelogin/wordpress-saml/commit/e857c7735e828f58f9c0dea788ae4ea85390514a#diff-c2929a37119c3b2eafb6e50b579eaefb)

please remerge and release on wordpress.org

Thanks!