### PR TITLE
Stop using `$blog_id` before it's defined

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -265,7 +265,7 @@ function saml_acs() {
 	}
 
 	if ($user_id) {
-		if (is_multisite() && !is_user_member_of_blog($user_id, $blog_id)) {
+		if (is_multisite() && !is_user_member_of_blog($user_id)) {
     	    if (get_option('onelogin_saml_autocreate')) {
     	    	//Exist's but is not user to the current blog id
     	    	$blog_id = get_current_blog_id();


### PR DESCRIPTION
Based on the way `is_user_member_of_blog(...)` works...
https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-includes/user.php#L703
... providing an undefined variable will work the same as not providing anything for
the optional `$blog_id` variable, so I'm simply removing it from this function call.
Fixes #67