### PR TITLE
Spelling fix for "Errors and Warnigs" on config page

### DIFF
--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -392,7 +392,7 @@ use RobRichards\XMLSecLibs\XMLSecurityKey;
 		$value = get_option('onelogin_saml_advanced_settings_debug');
 		echo '<input type="checkbox" name="onelogin_saml_advanced_settings_debug" id="onelogin_saml_advanced_settings_debug"
 			  '.($value ? 'checked="checked"': '').'>'.
-			  '<p class="description">'.__('Enable for debugging the SAML workflow. Errors and Warnigs will be shown.', 'onelogin-saml-sso').'</p>';
+			  '<p class="description">'.__('Enable for debugging the SAML workflow. Errors and Warnings will be shown.', 'onelogin-saml-sso').'</p>';
 	}
 
 	function plugin_setting_boolean_onelogin_saml_advanced_settings_strict_mode() {


### PR DESCRIPTION
This fixes a small spelling error on the configuration page.