### PR TITLE
Fix variable assignment during conditional check

### DIFF
--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -550,7 +550,7 @@ function onelogin_saml_global_configuration_multisite_save() {
 	check_admin_referer('network_saml_global_settings_validate'); // Nonce security check
 	
 	if (isset($_POST)) {
-		if (isset($_POST['global_jit']) && $_POST['global_jit'] = 'on') {
+		if (isset($_POST['global_jit']) && $_POST['global_jit'] === 'on') {
 			$global_jit = true;
 		} else {
 			$global_jit = false;


### PR DESCRIPTION
The global `$_POST['global_jit']` is being assigned the value of `on` in the conditional when the intention is to compare its value instead. This PR changes the assignment operator (`=`) to a comparison operator (`===`).