### PR TITLE
include the core plugin files on the login page

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -99,6 +99,11 @@ function checkIsExternalURLAllowed($url, $trustedSites = [])
 }
 
 function saml_custom_login_footer() {
+
+	if (!function_exists('is_plugin_active')) {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
 	$saml_login_message = get_option('onelogin_saml_customize_links_saml_login');
 	if (empty($saml_login_message)) {
 		$saml_login_message = "SAML Login";


### PR DESCRIPTION
Issue: https://github.com/onelogin/wordpress-saml/issues/129

Fixes the missing function error by including the WordPress core functions. I am not clear why newer versions of WP are breaking, but the root of the issue comes down to the plugin firing the `is_plugin_active` function before WordPress has loaded it.