### PR TITLE
Logged Out Errors

### DIFF
--- a/onelogin-saml-sso/onelogin_saml.php
+++ b/onelogin-saml-sso/onelogin_saml.php
@@ -123,7 +123,7 @@ function onelogin_enqueue_script() {
 	wp_enqueue_script( 'onelogin-hide-login-form', plugins_url( 'assets/js/hide-login-form.js', __FILE__ ), array('jquery'), null, true );
 }
 
-if ((strpos($_SERVER['SCRIPT_NAME'], 'wp-login.php') !== FALSE) && $action == 'login' && !isset($_GET['normal'])) {
+if ((strpos($_SERVER['SCRIPT_NAME'], 'wp-login.php') !== FALSE) && $action == 'login' && !isset($_GET['normal']) && !isset($_GET['loggedout'])) {
 	if (!get_option('onelogin_saml_keep_local_login', false)) {
 		add_action( 'login_enqueue_scripts', 'onelogin_enqueue_script', 10 );
 	}

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -105,8 +105,9 @@ function saml_custom_login_footer() {
 	}
 
 	$login_page = 'wp-login.php';
-	if (is_plugin_active('wps-hide-login/wps-hide-login.php')) {
-		$login_page = str_replace( 'wp-login.php', get_site_option( 'whl_page', 'login' ), $login_page ) . '/';
+	$active_plugins = get_option( 'active_plugins' );
+	if ( is_array( $active_plugins ) && ! empty( $active_plugins ) && in_array( 'wps-hide-login/wps-hide-login.php', $active_plugins, true ) ) {
+		$login_page = str_replace( 'wp-login.php', esc_url( get_site_option( 'whl_page', 'login' ) ), $login_page ) . '/';
 	}
 	
 	$redirect_to = isset($_GET['redirect_to']) ? '&redirect_to='.$_GET['redirect_to'] : '';


### PR DESCRIPTION
When logged out, the form is hidden.

However, when the login form is customised e.g. through another plugin, it can present an alternative facility to log in.

This PR introduces a fix to ensure that when logged out, the default WP login form is retained.